### PR TITLE
Fix: Displays 'on host [object Object]' in log

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -54,7 +54,7 @@ function deployForEnv(deploy_conf, env, args, cb) {
       jobs.push(function(done) {
 
         if (process.env.NODE_ENV !== 'test') {
-          console.log('--> on host %s', host);
+          console.log('--> on host %s', host.host ? host.host : host);
         }
 
         conf_copy.host = host;


### PR DESCRIPTION
Given provisioned **pm2-deploy** with multiple hosts like 

``` js
  deploy : {
    production : {
      user : "ubuntu",
      host: [
          {
            host : "121.201.7.226",
            port: "58020"
          },
          {
            host : "192.168.33.80",
            port: "22"
          }
      ],
  ...
```

When deploy to remote, the log cannot show correct host deploying instead of `[object Object]`

``` bash
$ pm2 deploy production setup
--> Deploying to production environment
--> on host [object Object]
  ○ running setup
  ○ cloning git@github.com:theone-dev/orange.git
```
