### PR TITLE
update pm2-deploy so that it will pull refs

### DIFF
--- a/deploy
+++ b/deploy
@@ -300,6 +300,13 @@ while test $# -ne 0; do
     setup)  setup $@; exit ;;
     list)  list_deploys; exit ;;
     config) config $@; exit ;;
+    *)
+      if test -z "$ENV"; then
+        ENV=$arg;
+      else
+        REF="$REF $arg";
+      fi
+      ;;
   esac
 done
 


### PR DESCRIPTION
Currently pm2-deploy does not contain the option to pull ref from command-line arg.  REF variable is not updated so it just uses ref from the ecosystem.json file.

This pull request is to add the ability to pull refs as provided for in the visionmedia deploy script as well.