### PR TITLE
Fix/Add ref option to support pulling remote refs

### DIFF
--- a/deploy
+++ b/deploy
@@ -45,7 +45,7 @@ usage() {
     prev[ious]           output previous release commit
     exec|run <cmd>       execute the given <cmd>
     list                 list previous deploy commits
-    [ref]                deploy to [ref], the 'ref' setting, or latest tag
+    ref [ref]            deploy [ref]
 
 EOF
 }

--- a/deploy
+++ b/deploy
@@ -300,8 +300,7 @@ while test $# -ne 0; do
     setup)  setup $@; exit ;;
     list)  list_deploys; exit ;;
     config) config $@; exit ;;
-    '') ;;
-    *) REF=$arg ;;
+    ref) REF=$1 ;;
   esac
 done
 

--- a/deploy
+++ b/deploy
@@ -302,7 +302,6 @@ while test $# -ne 0; do
     config) config $@; exit ;;
     ref) REF=$1 ;;
   esac
-  echo $REF
 done
 
 check_for_local_changes

--- a/deploy
+++ b/deploy
@@ -302,6 +302,7 @@ while test $# -ne 0; do
     config) config $@; exit ;;
     ref) REF=$1 ;;
   esac
+  echo $REF
 done
 
 check_for_local_changes

--- a/deploy
+++ b/deploy
@@ -168,7 +168,7 @@ setup() {
 deploy() {
   local ref=$1
   local path=`config_get path`
-  log deploying
+  log "deploying ${ref}"
 
   hook pre-deploy || abort pre-deploy hook failed
 
@@ -300,7 +300,7 @@ while test $# -ne 0; do
     setup)  setup $@; exit ;;
     list)  list_deploys; exit ;;
     config) config $@; exit ;;
-    *) REF=$arg; exit ;;
+    *) REF=$arg ;;
   esac
 done
 

--- a/deploy
+++ b/deploy
@@ -300,6 +300,7 @@ while test $# -ne 0; do
     setup)  setup $@; exit ;;
     list)  list_deploys; exit ;;
     config) config $@; exit ;;
+    '') ;;
     *) REF=$arg ;;
   esac
 done

--- a/deploy
+++ b/deploy
@@ -300,6 +300,7 @@ while test $# -ne 0; do
     setup)  setup $@; exit ;;
     list)  list_deploys; exit ;;
     config) config $@; exit ;;
+    *) REF=$arg; exit ;;
   esac
 done
 


### PR DESCRIPTION
REF variable is never set in the deploy script, this pull request adds the ref [ref] option to allow optionally passing a ref option. Unlike the previous pull request this still allows to not pass a ref which is then read from the config as normal.

i.e.
pm2 deploy environment.json5 staging ref origin/master

also 

pm2 deploy environment.json5 staging

will still function as currently.