### PR TITLE
add feature: deploy to localhost

### DIFF
--- a/deploy
+++ b/deploy
@@ -110,10 +110,33 @@ ssh_command() {
 # Run the given remote <cmd>.
 #
 
-run() {
+runRemote() {
   local shell="`ssh_command`"
   echo $shell "\"$@\"" >> $LOG
   $shell $@
+}
+
+#
+# Run the given local <cmd>.
+#
+
+runLocal() {
+  echo "\"$@\"" >> $LOG
+  /usr/bin/env bash -c "$*"
+}
+
+#
+# Run the given <cmd> either locally or remotely
+#
+
+run() {
+  local host="`config_get host`"
+  if [[ $host == localhost ]]
+  then
+    runLocal $@
+  else
+    runRemote $@
+  fi
 }
 
 #
@@ -176,7 +199,7 @@ deploy() {
   # PR #50
   log executing pre-deploy-local
   local pdl=`config_get pre-deploy-local`
-  $pdl
+  runLocal $pdl
 
   hook pre-deploy || abort pre-deploy hook failed
 


### PR DESCRIPTION
Hi,

This PR enables deployment to localhost (see #65).

To enable local deployment, simply set the `host` prop to `localhost`.  Other localhost-ish values such as `0.0.0.0` or `127.0.0.1` will not work.

As before, pm2-deploy is reliant on `bash`, so no news there.

Here's a sample configuration for a [node-red](http://nodered.org) deployment:

```json
{
  "apps": [
    {
      "name": "node-red",
      "script": "./node_modules/.bin/node-red",
      "env": {
        "DEBUG": "node-red*"
      }
    }
  ],
  "deploy": {
    "production": {
      "user": "boneskull",
      "host": "some-machine.local",
      "ref": "origin/master",
      "repo": "git@github.com:boneskull/some-repo.git",
      "path": "/var/node-red",
      "post-deploy": "npm rebuild --update-binary && pm2 startOrRestart ecosystem.json --env production",
      "env": {
        "NODE_ENV": "production"
      }
    },
    "dev": {
      "user": "boneskull",
      "host": "localhost",
      "ref": "master",
      "repo": ".",
      "path": "/var/node-red",
      "post-deploy": "npm rebuild --update-binary && pm2 startOrRestart ecosystem.json --env dev",
      "env": {
        "NODE_ENV": "dev"
      }
    }
  }
}
```

Notes on the above config:

- This particular app has its `node_modules` folder under VCS, so we execute `npm rebuild` to ensure it works on multiple platforms
- To enable `dev` deployment without needing to push to `origin`:
  - The `ref` for the `dev` deployment is simply `master` instead of `origin/master`
  - A repo of `.` means pm2-deploy will clone *from* the working directory

