### PR TITLE
added pre-setup and post-setup hooks

### DIFF
--- a/deploy
+++ b/deploy
@@ -175,6 +175,7 @@ hook() {
 setup() {
   local path=`config_get path`
   local repo=`config_get repo`
+  hook pre-setup || abort pre-setup hook failed
   run "mkdir -p $path/{shared/{logs,pids},source}"
   test $? -eq 0 || abort setup paths failed
   log running setup
@@ -183,6 +184,7 @@ setup() {
   test $? -eq 0 || abort failed to clone
   run "ln -sfn $path/source $path/current"
   test $? -eq 0 || abort symlink failed
+  hook post-setup || abort post-setup hook failed
   log setup complete
 }
 


### PR DESCRIPTION
Hi,

When setting up the remote environment, sometimes we may have to run commands to do extra configuration. For example writing the initial configuration file in shared path. I believe that pre-setup and post-setup hooks can help us . Please let me know your thoughts!

Thanks,
Sankaran
