### PR TITLE
fix #86 before it reaches bash

### DIFF
--- a/test/deploy.mocha.js
+++ b/test/deploy.mocha.js
@@ -1,4 +1,5 @@
 var EventEmitter = require('events').EventEmitter
+var path = require('path')
 var childProcess = require('child_process')
 var deploy = require('../deploy.js')
 
@@ -223,7 +224,7 @@ describe('deploy', function() {
             echoData.ref.should.eql(conf.staging.ref)
             echoData.user.should.eql(conf.staging.user)
             echoData.repo.should.eql(conf.staging.repo)
-            echoData.path.should.eql(conf.staging.path)
+            echoData.path.should.eql(path.resolve(conf.staging.path))
             echoData.host.should.eql(hosts[spawnCount])
 
             spawnCount += 1


### PR DESCRIPTION
This fix addresses #86 without touching the bash script. bash can then do whatever it wants without blowing up when `$path` was provided as relative.

I made a bash version here: https://github.com/naugtur/pm2-deploy/commit/59e14be92920d2002a8303a09b8cdb4a98b9e9b6 but the bash script has no tests and is a bit scary to me, so I prefer this version.