### PR TITLE
added ssh_options extention

### DIFF
--- a/deploy
+++ b/deploy
@@ -98,12 +98,14 @@ ssh_command() {
   local forward_agent="`config_get forward-agent`"
   local port="`config_get port`"
   local needs_tty="`config_get needs_tty`"
+  local ssh_options="`config_get ssh_options`"
 
   test -n "$forward_agent" && local agent="-A"
   test -n "$key" && local identity="-i $key"
   test -n "$port" && local port="-p $port"
   test -n "$needs_tty" && local tty="-t"
-  echo "ssh $tty $agent $port $identity $url"
+  test -n "ssh_options" && local ssh_opts="$ssh_options"
+  echo "ssh $ssh_opts $tty $agent $port $identity $url"
 }
 
 #

--- a/deploy.js
+++ b/deploy.js
@@ -36,6 +36,17 @@ function deployForEnv(deploy_conf, env, args, cb) {
   if (!deploy_conf[env]) return cb(env + ' not defined in deploy section');
 
   var target_conf = deploy_conf[env];
+
+  if(target_conf.ssh_options) {
+    var ssh_opt = '';
+    if(Array.isArray(target_conf.ssh_options)) {
+      ssh_opt = '-o ' + target_conf.ssh_options.join(' -o ');
+    } else {
+      ssh_opt = '-o ' + target_conf.ssh_options;
+    }
+    target_conf.ssh_options = ssh_opt;
+  }
+
   var piped_data  = JSON.stringify(target_conf);
 
   if (!tv4.validate(target_conf, {


### PR DESCRIPTION
Hi,

when i want to deploy for the first time on a server from another using pm2 i need to add the ssh key to the known hosts of the server 
in my case: from jenkins --> app server
in this case i need a user interaction:

Are you sure you want to continue connecting (yes/no)? yes
however connecting to the server with ssh using the _StrictHostKeyChecking_ option overdo this interaction

```
ssh -o StrictHostKeyChecking=no username@hostname.com
```

Is there a way to overgive pm2 options for the ssh connection?

Thanks in advance

See: https://github.com/Unitech/pm2/issues/2157
