### PR TITLE
Fix an error when deploy's path has spaces

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -11,7 +11,7 @@ var childProcess = require('child_process');
  * @callback cb
  */
 function spawn(hostJSON, args, cb) {
-  var shellSyntaxCommand = "echo '" + hostJSON + "' | " + __dirname.replace(/\\/g, '/') + "/deploy " + args.join(' ');
+  var shellSyntaxCommand = "echo '" + hostJSON + "' | \"" + __dirname.replace(/\\/g, '/') + "/deploy\" " + args.join(' ');
   var proc = childProcess.spawn('sh', ['-c', shellSyntaxCommand], { stdio: 'inherit' });
 
   proc.on('error', function(e) {


### PR DESCRIPTION
If the pm2-deploy package is located in a path that has spaces in it (can happen in Windows) this line was failing,
This fix makes sure the path is taken as a single argument.