### PR TITLE
Fixed a bug if package path contains spaces

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -11,7 +11,7 @@ var childProcess = require('child_process');
  * @callback cb
  */
 function spawn(hostJSON, args, cb) {
-  var shellSyntaxCommand = "echo '" + hostJSON + "' | " + __dirname.replace(/\\/g, '/') + "/deploy " + args.join(' ');
+  var shellSyntaxCommand = "echo '" + hostJSON + "' | \"" + __dirname.replace(/\\/g, '/') + "/deploy\" " + args.join(' ');
   var proc = childProcess.spawn('sh', ['-c', shellSyntaxCommand], { stdio: 'inherit' });
 
   proc.on('error', function(e) {

--- a/test/deploy.mocha.js
+++ b/test/deploy.mocha.js
@@ -153,7 +153,7 @@ describe('deploy', function() {
             spawnCalls[0][1][1].should.be.a.String
             var pipeTo = spawnCalls[0][1][1].split(/\s*\|\s*/)[1]
             pipeTo.should.be.ok
-            pipeTo.should.match(/\/deploy\s*$/)
+            pipeTo.should.match(/\/deploy"\s*$/)
             done()
           })
         })


### PR DESCRIPTION
Fixed a bug there if the package was installed under a path containing spaces (can happen in windows), the shell command would fail