### PR TITLE
fetch all tags from the remote

### DIFF
--- a/deploy
+++ b/deploy
@@ -205,7 +205,7 @@ deploy() {
 
   # fetch source
   log fetching updates
-  run "cd $path/source && git fetch --all"
+  run "cd $path/source && git fetch --all --tags"
   test $? -eq 0 || abort fetch failed
 
   # latest tag


### PR DESCRIPTION
Deployment will fail if trying to deploy a tag that's not on the branch.