### PR TITLE
fix setup when the branch is not the default one

### DIFF
--- a/deploy
+++ b/deploy
@@ -201,12 +201,14 @@ hook_pre_setup() {
 setup() {
   local path=`config_get path`
   local repo=`config_get repo`
+  local ref=`config_get ref`
+  local branch=${ref##*/}
   hook_pre_setup || abort pre-setup hook failed
   run "mkdir -p $path/{shared/{logs,pids},source}"
   test $? -eq 0 || abort setup paths failed
   log running setup
   log cloning $repo
-  run "git clone --depth=5 $repo $path/source"
+  run "git clone --depth=5 --branch $branch $repo $path/source"
   test $? -eq 0 || abort failed to clone
   run "ln -sfn $path/source $path/current"
   test $? -eq 0 || abort symlink failed


### PR DESCRIPTION
fix a bug introduced in https://github.com/Unitech/pm2-deploy/commit/832f725be480c608c19f51a56ed51d73a2986758
this fix the deploy setup when the branch is different from the default one