### PR TITLE
Fix problems caused by “git fetch --depth=5 --all --tags”

### DIFF
--- a/deploy
+++ b/deploy
@@ -235,7 +235,7 @@ deploy() {
 
   # fetch source
   log fetching updates
-  run "cd $path/source && git fetch --depth=5 --all --tags"
+  run "cd $path/source && git fetch --depth=5 --all"
   test $? -eq 0 || abort fetch failed
 
   # latest tag


### PR DESCRIPTION
Depend on the document：

· git fetch fetches all branch heads (or all specified by the remote.fetch config option), all commits necessary for them, and all tags which are reachable from these branches. In most cases, all tags are reachable in this way.

· git fetch --tags fetches all tags, all commits necessary for them. It will not update branch heads, even if they are reachable from the tags which were fetched.

Before running "git reset --hard $ref",the branch heads must have been updated.So the "--tags" cannot be added.