### PR TITLE
Fix always deploy to default branch problem

### DIFF
--- a/deploy
+++ b/deploy
@@ -209,14 +209,15 @@ setup() {
   local ref=`config_get ref`
   local fetch=`config_get fetch`
   local branch=${ref#*/}
+
   hook_pre_setup || abort pre-setup hook failed
   run "mkdir -p $path/{shared/{logs,pids},source}"
   test $? -eq 0 || abort setup paths failed
   log running setup
   log cloning $repo
-  if test fetch != "fast"; then
+  if test $fetch != "fast"; then
     log "full fetch"
-    run "git clone $repo $path/source"
+    run "git clone --branch $branch $repo $path/source"
   else
     log "fast fetch"
     run "git clone --depth=5 --branch $branch $repo $path/source"
@@ -234,6 +235,10 @@ setup() {
 
 deploy() {
   local ref=$1
+  local branch=$2
+  if test -z "$branch"; then
+    branch=${ref#*/}
+  fi
   local path=`config_get path`
   local fetch=`config_get fetch`
 
@@ -249,7 +254,7 @@ deploy() {
   # fetch source
   log fetching updates
 
-  if test fetch != "fast"; then
+  if test $fetch != "fast"; then
     log "full fetch"
     run "cd $path/source && git fetch --all --tags"
   else
@@ -269,10 +274,10 @@ deploy() {
     test $? -eq 0 || abort failed to determine latest tag
   fi
 
-  # reset HEAD
-  log resetting HEAD to $ref
-  run "cd $path/source && git reset --hard $ref"
-  test $? -eq 0 || abort git reset failed
+  # checkout ref to branch
+  log checkout $ref to $branch
+  run "cd $path/source && git checkout $ref -b $branch"
+  test $? -eq 0 || abort git checkout failed
 
   # link current
   run "ln -sfn $path/source $path/current"
@@ -384,11 +389,11 @@ while test $# -ne 0; do
     setup)  setup $@; exit ;;
     list)  list_deploys; exit ;;
     config) config $@; exit ;;
-    ref) REF=$1 ;;
+    ref) REF=$1; BRANCH=$2 ;;
   esac
 done
 
 check_for_local_changes
 
 # deploy
-deploy "${REF:-`config_get ref`}"
+deploy "${REF:-`config_get ref`}" "${BRANCH}"


### PR DESCRIPTION
this PR fixes Unitech/pm2#3803

what this PR does:
- fixed `if test fetch != "fast";` always return true problem
- always clone to the specified branch regardless fetch type
- use `checkout` instead of `hard reset` for deployment
- allow `ref` options to have a optional branch name

`ref` example
following command deploy tag `prod-v1.0.1` to new branch named `v1.0.1`
```
pm2 deploy production ref tags/prod-v1.0.1 v1.0.1
```
if the optional branch name omitted, the tag will be deploy to branch named `prod-v1.0.1`

the `ref` command can also use for branch deployment
```
pm2 deploy production ref develop
```
