### PR TITLE
fix(deploy): fix git ref verify

### DIFF
--- a/deploy
+++ b/deploy
@@ -251,7 +251,7 @@ deploy() {
 
   hook pre-deploy || abort pre-deploy hook failed
 
-  if run "cd $path/source && git rev-parse --quiet --verify $branch" > /dev/null; then
+  if run "cd $path/source && git cat-file -t $branch" > /dev/null; then
     log fast forward $branch
     run "cd $path/source && git checkout $branch && git pull origin $branch"
     test $? -eq 0 || abort git pull failed


### PR DESCRIPTION
This problem is encountered when deploying with `pm2 deploy ref ref_hash`.

`git rev-parse --quiet --verify ${ref_hash}` does not check if `ref_hash` really exists, it only checks if the format is valid.

For example, the command can be executed under the current repo:

```bash
# true ref
git rev-parse --quiet --verify 4e9655c042fa43ea82506cf5f4fad583a880568d

# fake ref
git rev-parse --quiet --verify 4e9655c042fa43ea82506cf5f4fad583a8805680
```