### PR TITLE
Control logging through `options.logging` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Deploy to a single environment
 -   `deployConfig` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** object containing deploy configs for all environments
 -   `env` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the name of the environment to deploy to
 -   `args` **[array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** custom deploy command-line arguments
+-   `options` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** deploy options (optional, default `{}`)
+    -   `options.logging` **([boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean) \| [function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function))** logging function or `false` to disable logging (optional, default `console.log`)
 -   `cb` **[DeployCallback](#deploycallback)** done callback
 
 Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** return value is always `false`

--- a/deploy.js
+++ b/deploy.js
@@ -7,6 +7,8 @@ var path = require('path');
 var series = require('run-series');
 var tv4 = require('tv4');
 
+var noop = Function.prototype;
+
 var schema = {
   type: 'object',
   properties: {
@@ -32,10 +34,10 @@ function spawn(config, args, cb) {
 
   args = args || [];
   if (args.length > 0) {
-    var cmdArgs = args.map(function (arg) {
-      return format('"%s"', arg);
-    }).join(' ');
-    cmd = [cmd, cmdArgs].join(' ');
+    cmd = args.reduce(function (acc, arg) {
+      acc += format(' "%s"', arg);
+      return acc;
+    }, cmd).trim();
   }
 
   var proc = child_process.spawn('sh', ['-c', cmd], { stdio: 'inherit' });
@@ -53,6 +55,10 @@ function spawn(config, args, cb) {
   });
 }
 
+function isFunction(arg) {
+  return typeof arg === 'function';
+}
+
 function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
@@ -66,29 +72,39 @@ function castArray(arg) {
  * @param {object} deployConfig object containing deploy configs for all environments
  * @param {string} env the name of the environment to deploy to
  * @param {array} args custom deploy command-line arguments
+ * @param {object} [options={}] deploy options
+ * @param {boolean|function} [options.logging=console.log] logging function or `false` to disable logging
  * @param {DeployCallback} cb done callback
  * @returns {boolean} return value is always `false`
  */
-function deployForEnv(deployConfig, env, args, cb) {
+function deployForEnv(deployConfig, env, args, options, cb) {
+  if (isFunction(options)) {
+    cb = options;
+    options = {};
+  }
+
+  options = options || {};
+  options.logging = options.hasOwnProperty('logging') ? options.logging : console.log;
+  if (options.logging === true) options.logging = console.log;
+
+  var log = isFunction(options.logging) ? options.logging : noop;
+
   if (!deployConfig[env]) {
     return cb(new Error(format('%s not defined in deploy section', env)));
   }
 
   var envConfig = clone(deployConfig[env]);
-
-  if (envConfig.ssh_options) {
-    envConfig.ssh_options = castArray(envConfig.ssh_options).map(function (option) {
-      return format('-o %s', option);
-    }).join(' ');
-  }
-
   var result = tv4.validateResult(envConfig, schema);
   if (!result.valid) {
     return cb(result.error);
   }
 
-  if (process.env.NODE_ENV !== 'test') {
-    console.log('--> Deploying to %s environment', env);
+  if (envConfig.ssh_options) {
+    envConfig.ssh_options = castArray(envConfig.ssh_options)
+      .reduce(function (acc, option) {
+        acc += format(' -o %s', option);
+        return acc;
+      }, '').trim();
   }
 
   if (process.platform !== 'win32') {
@@ -98,19 +114,18 @@ function deployForEnv(deployConfig, env, args, cb) {
   var hosts = castArray(envConfig.host);
   var jobs = hosts.map(function (host) {
     return function job(done) {
-      if (process.env.NODE_ENV !== 'test') {
-        console.log('--> on host %s', host.host ? host.host : host);
-      }
-
       var config = clone(envConfig);
       config.host = host;
       config['post-deploy'] = prependEnv(config['post-deploy'], config.env);
 
+      log(format('--> on host %s', host));
       spawn(config, args, done);
     };
   });
+
+  log(format('--> Deploying to %s environment', env));
   series(jobs, function (err, result) {
-    result = Array.isArray(envConfig.host) ? result : result[0];
+    if (!Array.isArray(envConfig.host)) result = result && result[0];
     cb(err, result);
   });
 
@@ -119,9 +134,11 @@ function deployForEnv(deployConfig, env, args, cb) {
 
 function envToString(env) {
   env = env || {};
-  return Object.keys(env).map(function (name) {
-    return format('%s=%s', name.toUpperCase(), env[name]);
-  }).join(' ');
+  return Object.keys(env)
+    .reduce(function (acc, name) {
+      acc += format(' %s=%s', name.toUpperCase(), env[name]);
+      return acc;
+    }, '').trim();
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/Unitech/pm2-deploy.git"
   },
   "scripts": {
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint .",
     "test": "mocha",
     "docs": "documentation readme ./deploy.js --section=API"
   },


### PR DESCRIPTION
This PR introduces optional `options` param to `deployForEnv` function changing its signature to:
```js
/**
 * Deploy to a single environment
 * @param {object} deployConfig object containing deploy configs for all environments
 * @param {string} env the name of the environment to deploy to
 * @param {array} args custom deploy command-line arguments
 * @param {object} [options={}] deploy options
 * @param {boolean|function} [options.logging=console.log] logging function or `false` to disable logging
 * @param {DeployCallback} cb done callback
 * @returns {boolean} return value is always `false`
 */
function deployForEnv(deployConfig, env, args, options, cb) { ... }
```
This enables control of logging behavior from outside instead of hardcoding `console.log` calls 🔧 