### PR TITLE
Update deploy to allow multiple deployments with different Users

### DIFF
--- a/deploy
+++ b/deploy
@@ -9,7 +9,7 @@
 
 VERSION="0.6.0"
 CONFIG=./deploy.conf
-LOG=/tmp/pm2-deploy.log
+LOG=/tmp/pm2-deploy-${USER:-default}.log
 TEST=1
 FORCE=0
 REF=


### PR DESCRIPTION
Adds the Username to the logfile name, so it won' clash with other Users doing a deployment on the machine. Defaults to 'default', If USER is unset.

Fixes Issue **https://github.com/Unitech/pm2-deploy/issues/39**