### PR TITLE
Updates prependEnv() to use PM2_ variables.

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -118,7 +118,6 @@ function deployForEnv(deployConfig, env, args, cb) {
 }
 
 function envToString(env) {
-  env = env || {};
   return Object.keys(env).map(function (name) {
     return format('%s=%s', name.toUpperCase(), env[name]);
   }).join(' ');
@@ -132,7 +131,14 @@ function envToString(env) {
  * @returns {string} concatenated shell command
  */
 function prependEnv(cmd, env) {
-  const envVars = envToString(env);
+  env = env || {};
+  const envAndPm2EnvVars = Object.keys(process.env)
+    .filter((key) => key.startsWith("PM2_"))
+    .reduce(
+      (obj, key) => Object.assign(obj, { [key.slice(4)]: process.env[key] }),
+      env
+    );
+  const envVars = envToString(envAndPm2EnvVars);
   if (!envVars) return cmd;
   if (!cmd) return format('export %s', envVars);
   return format('export %s && %s', envVars, cmd);


### PR DESCRIPTION
This is my proposed resolution to Issue #37.

A routine has been added to prependEnv() to filter from the process
environment any variable beggining with "PM2_" and add them to the rest
of the environment variables.

Note that the prefix of "PM2_" is truncated from the variable name when applied to the environment of the application.

For example: `$ PM2_AUTHTOKEN=setecastronomy pm2 deploy ecosystem.config.js production` would set the environment variable `AUTHTOKEN` when running the application, available in Node as `process.env.AUTHTOKEN`.